### PR TITLE
Fix so it passes tests. Store config in each node.type file.

### DIFF
--- a/save_draft.info
+++ b/save_draft.info
@@ -2,5 +2,4 @@ name = Save Draft
 description = Adds a 'Save as Draft' button to content types
 backdrop = 1.x
 type = module
-
-//files[] = save_draft.test
+package = User interface

--- a/save_draft.install
+++ b/save_draft.install
@@ -6,21 +6,42 @@
  */
 
 /**
- * Implements hook_uninstall().
+ * Implements hook_install().
+ *
+ * Enable Save draft by default on each content type.
  */
-function save_draft_uninstall() {
-  foreach (node_type_get_names('names') as $type => $type_name) {
-    //TODO: See if this necessary
-    //variable_del('save_draft_enabled_' . $type);
-    //variable_del('save_draft_skip_required_' . $type);
+function save_draft_install() {
+  $settings = array('draft_enabled', 'skip_required');
+  foreach (node_type_get_types() as $type) {
+    config_set('node.type.' . $type->type, 'settings.draft_enabled', 1);
+    config_set('node.type.' . $type->type, 'settings.skip_required', 0);
   }
 }
 
-
-function save_draft_install() {
-  $config = config('save_draft.settings');
+/**
+ * Implements hook_uninstall().
+ */
+function save_draft_uninstall() {
   foreach (node_type_get_types() as $type) {
-    $config->set('enabled_' . $type->type, TRUE);
+    $config = config('node.type.' . $type->type);
+    $config->clear('settings.draft_enabled');
+    $config->clear('settings.skip_required');
+    $config->save();
+  }
+}
+
+/**
+ * Update config so variables are stored in the node type config.
+ */
+function save_draft_update_1000() {
+  $config = config('save_draft.settings');
+  $settings = array('draft_enabled', 'skip_required');
+  foreach (node_type_get_types() as $type) {
+    $setting['draft_enabled'] = $config->get('enabled_' . $type->type);
+    $setting['skip_required'] = $config->get('skip_required_' . $type->type);
+    config_set('node.type.' . $type->type, 'settings.draft_enabled', $setting['draft_enabled']);
+    config_set('node.type.' . $type->type, 'settings.skip_required', $setting['skip_required']);
+    $config->delete('save_draft.settings');
   }
   $config->save();
 }

--- a/save_draft.module
+++ b/save_draft.module
@@ -16,10 +16,21 @@ define('SAVE_DRAFT_DISABLED', 0);
 define('SAVE_DRAFT_ENABLED', 1);
 
 /**
+ * Implements hook_config_info().
+ */
+function save_draft_config_info() {
+  $prefixes['save_draft.settings'] = array(
+    'label' => t('Save draft settings'),
+    'group' => t('Configuration'),
+  );
+  return $prefixes;
+}
+
+/**
  * Implements hook_permission().
  */
 function save_draft_permission() {
-  array(
+  return array(
     'save draft' => array(
       'title' => t('Save content as draft'),
       'description' => t('Allows people with permission to view and edit their own unpublished content to change the published state of their content when saving it.'),
@@ -37,8 +48,8 @@ function save_draft_permission() {
  * unpublished.
  */
 function save_draft_form_node_form_alter(&$form, &$form_state) {
-  $config = config('save_draft.settings');
-  if ($config->get('enabled_' . $form['#node']->type) && save_draft_access($form, $form_state)) {
+  $enabled = config_get('node.type.' . $form['#node']->type, 'settings.draft_enabled');
+  if ($enabled && save_draft_access($form, $form_state)) {
     // Remove the status checkbox from the options fieldset, and adjust the
     // fieldset accordingly.
     if (isset($form['options']['status'])) {
@@ -65,7 +76,7 @@ function save_draft_form_node_form_alter(&$form, &$form_state) {
       '#type' => 'submit',
       '#class' => 'form-submit',
       '#submit' => array('save_draft_draft_button_submit'),
-      // Between the default Save and Preview buttons.
+      // Between the default Save and Delete buttons.
       '#weight' => 9,
     );
 
@@ -87,13 +98,10 @@ function save_draft_form_node_form_alter(&$form, &$form_state) {
       $form['actions']['submit']['#value'] = t('Save');
       $form['actions']['draft']['#value'] = t('Unpublish');
     }
-
-    if ($config->get('skip_required_' . $form['#node']->type)) {
+    $skip_required = config_get('node.type.' . $form['#node']->type, 'settings.skip_required');
+    if ($skip_required) {
       // Add a flag to buttons that can skip required validation.
       $form['actions']['draft']['#skip_required_validation'] = TRUE;
-      if (isset($form['actions']['preview'])) {
-        $form['actions']['preview']['#skip_required_validation'] = TRUE;
-      }
       if (isset($form['actions']['delete'])) {
         $form['actions']['delete']['#skip_required_validation'] = TRUE;
       }
@@ -133,12 +141,10 @@ function save_draft_validate($form, &$form_state) {
  * Implements hook_form_FORM_ID_alter() for the node type form.
  */
 function save_draft_form_node_type_form_alter(&$form, &$form_state) {
-  $config = config('save_draft.settings');
-  $enabled = $config->get('enabled_' . $form['#node_type']->type);
-  $skip_required = $config->get('skip_required_' . $form['#node_type']->type);
-
+  $enabled = config_get('node.type.' . $form['#node_type']->type, 'settings.draft_enabled');
+  $skip_required = config_get('node.type.' . $form['#node_type']->type, 'settings.skip_required');
   $options = array(
-    'enabled' => t('Enable "Save Draft" button on this content type'),
+    'draft_enabled' => t('Enable "Save Draft" button on this content type'),
     'skip_required' => t('Allow drafts to skip required fields'),
   );
 
@@ -146,15 +152,21 @@ function save_draft_form_node_type_form_alter(&$form, &$form_state) {
     '#title' => t('Save Draft'),
     '#type' => 'checkboxes',
     '#options' => $options,
-    '#default_value' => array (
-      'enabled' => $enabled,
-      'skip_required' => $skip_required,
-    ),
     '#attached' => array(
       'js' => array(
         'save-draft' => backdrop_get_path('module', 'save_draft') . '/js/save_draft.js',
       ),
     ),
+  );
+  $form['workflow']['save_draft']['draft_enabled'] = array(
+    '#default_value' => $enabled,
+    '#parents' => array('draft_enabled'),
+    '#return_value' => 1,
+  );
+  $form['workflow']['save_draft']['skip_required'] = array(
+    '#default_value' => $skip_required,
+    '#parents' => array('skip_required'),
+    '#return_value' => 1,
   );
 
   $form['#submit'][] = 'save_draft_form_node_type_form_submit';
@@ -164,10 +176,8 @@ function save_draft_form_node_type_form_alter(&$form, &$form_state) {
    * Submit handler for the new "Save Draft" options on the Content Type edit form.
    */
 function save_draft_form_node_type_form_submit($form, &$form_state) {
-  $config = config('save_draft.settings');
-  if (isset($form_state['values']['save_draft']['enabled'])) $config->set('enabled_'.$form_state['values']['type'],$form_state['values']['save_draft']['enabled']);
-  if (isset($form_state['values']['save_draft']['skip_required'])) $config->set('skip_required_'.$form_state['values']['type'],$form_state['values']['save_draft']['skip_required']);
-  $config->save();
+  config_set('node.type.' . $form['#node_type']->type, 'settings.draft_enabled', $form_state['values']['draft_enabled']);
+  config_set('node.type.' . $form['#node_type']->type, 'settings.skip_required', $form_state['values']['skip_required']);
 }
 
 /**
@@ -207,14 +217,6 @@ function save_draft_access($form, &$form_state) {
   }
 
   return $access;
-}
-
-/**
- * Implements hook_node_type_delete().
- */
-function save_draft_node_type_delete($info) {
-  //TODO: Figure out if this is necessary in Backdrop
-  variable_del('save_draft_enabled_' . $info->type);
 }
 
 /**

--- a/save_draft.module
+++ b/save_draft.module
@@ -16,17 +16,6 @@ define('SAVE_DRAFT_DISABLED', 0);
 define('SAVE_DRAFT_ENABLED', 1);
 
 /**
- * Implements hook_config_info().
- */
-function save_draft_config_info() {
-  $prefixes['save_draft.settings'] = array(
-    'label' => t('Save draft settings'),
-    'group' => t('Configuration'),
-  );
-  return $prefixes;
-}
-
-/**
  * Implements hook_permission().
  */
 function save_draft_permission() {

--- a/tests/save_draft.test
+++ b/tests/save_draft.test
@@ -5,18 +5,10 @@ class SaveDraftTestCase extends BackdropWebTestCase {
   protected $admin_user;
   protected $save_draft_user;
 
-  public static function getInfo() {
-    return array(
-      'name' => 'Save draft',
-      'description' => 'Make sure the node form still works with Save Draft enabled.',
-      'group' => 'Save draft',
-    );
-  }
-
   public function setUp() {
     parent::setUp(array('save_draft'));
     $this->admin_user = $this->BackdropCreateUser(array('administer nodes', 'bypass node access'));
-    $this->save_draft_user = $this->BackdropCreateUser(array('create article content', 'edit any article content', 'view own unpublished content', 'save draft'));
+    $this->save_draft_user = $this->BackdropCreateUser(array('create post content', 'edit any post content', 'view own unpublished content', 'save draft'));
     $langcode = LANGUAGE_NONE;
     $this->title_key = "title";
     $this->body_key = "body[$langcode][0][value]";
@@ -39,23 +31,23 @@ class SaveDraftTestCase extends BackdropWebTestCase {
     // Log in as a user who should see the save draft button.
     $this->BackdropLogin($this->save_draft_user);
 
-    // Make sure save draft is enabled for articles.
-    config_set('save_draft.settings','enabled_article', SAVE_DRAFT_ENABLED);
+    // Make sure save draft is enabled for posts.
+    config_set('node.type.post','settings.draft_enabled', SAVE_DRAFT_ENABLED);
 
     // Make sure the save draft button is present when adding a node and drafts
     // are enabled.
-    $this->BackdropGet('node/add/article');
-    $this->assertRaw('<input type="submit" id="edit-draft" name="op" value="' . t('Save as draft') . '" class="form-submit" />', t('Save draft enabled successfully on node create.'));
+    $this->BackdropGet('node/add/post');
+    $this->assertRaw('<input class="button-secondary form-submit" type="submit" id="edit-draft" name="op" value="' . t('Save as draft') . '" />', t('Save draft enabled successfully on node create.'));
     // Publish a node, and make sure it's published.
     $edit = $this->getNodeArray();
-    $this->BackdropPost('node/add/article', $edit, t('Publish'));
+    $this->BackdropPost('node/add/post', $edit, t('Publish'));
     $node = $this->BackdropGetNodeByTitle($edit[$this->title_key]);
     $this->assertEqual($node->status, NODE_PUBLISHED, t('Node saved correctly.'));
 
     // Make sure the unpublish button is present when on a published node and
     // drafts are enabled.
     $this->BackdropGet('node/' . $node->nid . '/edit');
-    $this->assertRaw('<input type="submit" id="edit-draft" name="op" value="' . t('Unpublish') . '" class="form-submit" />', t('Save draft enabled successfully on published node edit.'));
+    $this->assertRaw('<input class="button-secondary form-submit" type="submit" id="edit-draft" name="op" value="' . t('Unpublish') . '" />', t('Save draft enabled successfully on published node edit.'));
     // Unpublish it, and make sure it's unpublished.
     $this->BackdropPost('node/' . $node->nid . '/edit', array(), t('Unpublish'));
     $node = node_load($node->nid, NULL, TRUE);
@@ -63,34 +55,34 @@ class SaveDraftTestCase extends BackdropWebTestCase {
 
     // Save a new node as a draft, and make sure it's unpublished.
     $edit = $this->getNodeArray();
-    $this->BackdropPost('node/add/article', $edit, t('Save as draft'));
+    $this->BackdropPost('node/add/post', $edit, t('Save as draft'));
     $node = $this->BackdropGetNodeByTitle($edit[$this->title_key]);
     $this->assertEqual($node->status, NODE_NOT_PUBLISHED, t('Node saved correctly as draft.'));
 
     // Make sure the unpublish button is present when on a draft node and
     // drafts are enabled.
     $this->BackdropGet('node/' . $node->nid . '/edit');
-    $this->assertRaw('<input type="submit" id="edit-draft" name="op" value="' . t('Save') . '" class="form-submit" />', t('Save draft enabled successfully on draft node edit.'));
+    $this->assertRaw('<input class="button-primary form-submit" type="submit" id="edit-draft" name="op" value="' . t('Save as draft') . '" />', t('Save draft enabled successfully on draft node edit.'));
     // Publish the node, and make sure it's published.
     $this->BackdropPost('node/' . $node->nid . '/edit', array(), t('Publish'));
     $node = node_load($node->nid, NULL, TRUE);
     $this->assertEqual($node->status, NODE_PUBLISHED, t('Node published correctly.'));
 
-    // Make sure save draft is disabled for articles.
-    config_set('save_draft.settings','enabled_article', SAVE_DRAFT_DISABLED);
+    // Make sure save draft is disabled for posts.
+    config_set('node.type.post','settings.draft_enabled', SAVE_DRAFT_DISABLED);
 
     // Make sure the save draft button is not present when adding a node and
     // drafts are disabled.
-    $this->BackdropGet('node/add/article');
-    $this->assertNoRaw('<input type="submit" id="edit-draft" name="op" value="' . t('Save as draft') . '" class="form-submit" />', t('Save draft disabled successfully on node create.'));
+    $this->BackdropGet('node/add/post');
+    $this->assertNoRaw('<input class="button-secondary form-submit" type="submit" id="edit-draft" name="op" value="' . t('Save as draft') . '" />', t('Save draft disabled successfully on node create.'));
     // Publish a node and edit it again.
     $edit = $this->getNodeArray();
-    $this->BackdropPost('node/add/article', $edit, t('Save'));
+    $this->BackdropPost('node/add/post', $edit, t('Save'));
     $node = $this->BackdropGetNodeByTitle($edit[$this->title_key]);
     // Make sure the unpublish button is present when on a published node and
     // drafts are disabled.
     $this->BackdropGet('node/' . $node->nid . '/edit');
-    $this->assertNoRaw('<input type="submit" id="edit-draft" name="op" value="' . t('Unpublish') . '" class="form-submit" />', t('Save draft disabled successfully on published node edit.'));
+    $this->assertNoRaw('<input class="button-secondary form-submit" type="submit" id="edit-draft" name="op" value="' . t('Unpublish') . '" />', t('Save draft disabled successfully on published node edit.'));
   }
 
   /**
@@ -104,10 +96,10 @@ class SaveDraftTestCase extends BackdropWebTestCase {
     // Test with & without required validation.
     foreach (array(TRUE, FALSE) as $skip_required_validation) {
       debug('Skip required validation: ' . ($skip_required_validation ? 'true' : 'false'));
-      config_set('save_draft.settings','skip_required_article', $skip_required_validation);
+      config_set('node.type.post','settings.skip_required', $skip_required_validation);
 
       // Test clicking all the different buttons on the node add page.
-      foreach (array(t('Publish'), t('Save as draft'), t('Preview')) as $button_value) {
+      foreach (array(t('Publish'), t('Save as draft')) as $button_value) {
         debug('Node add. Button value: ' . $button_value);
         // Try to create a node with a nonexistent author.
         $edit = $this->getNodeArray();
@@ -115,7 +107,7 @@ class SaveDraftTestCase extends BackdropWebTestCase {
         unset($edit[$this->title_key]);
         // This username does not exist.
         $edit['name'] = $this->randomName(8);
-        $this->BackdropPost('node/add/article', $edit, $button_value);
+        $this->BackdropPost('node/add/post', $edit, $button_value);
 
         // Username validation should always fail.
         $this->assertRaw(t('The username %name does not exist.', array('%name' => $edit['name'])));
@@ -133,10 +125,10 @@ class SaveDraftTestCase extends BackdropWebTestCase {
       }
       // Test clicking all the different buttons on the node edit page of a
       // published node.
-      foreach (array(t('Save'), t('Unpublish'), t('Preview'), t('Delete')) as $button_value) {
+      foreach (array(t('Save'), t('Unpublish'), t('Delete')) as $button_value) {
         debug('Published node edit. Button value: ' . $button_value);
         $edit = $this->getNodeArray();
-        $this->BackdropPost('node/add/article', $edit, t('Publish'));
+        $this->BackdropPost('node/add/post', $edit, t('Publish'));
         $node = $this->BackdropGetNodeByTitle($edit[$this->title_key]);
         // Remove the title, which is a required field.
         $edit[$this->title_key] = '';
@@ -159,10 +151,10 @@ class SaveDraftTestCase extends BackdropWebTestCase {
       }
       // Test clicking all the different buttons on the node edit page of a
       // draft node.
-      foreach (array(t('Save'), t('Publish'), t('Preview'), t('Delete')) as $button_value) {
+      foreach (array(t('Save as draft'), t('Publish'), t('Delete')) as $button_value) {
         debug('Draft node edit. Button value: ' . $button_value);
         $edit = $this->getNodeArray();
-        $this->BackdropPost('node/add/article', $edit, t('Save as draft'));
+        $this->BackdropPost('node/add/post', $edit, t('Save as draft'));
         $node = $this->BackdropGetNodeByTitle($edit[$this->title_key]);
         // Remove the title, which is a required field.
         $edit[$this->title_key] = '';

--- a/tests/save_draft.tests.info
+++ b/tests/save_draft.tests.info
@@ -1,0 +1,5 @@
+[SaveDraftTestCase]
+name = Save draft tests
+description = Make sure the node form still works with Save Draft enabled.
+group = Save draft
+file = save_draft.test


### PR DESCRIPTION
@laryn I've created this PR primarily to get the tests passing. There was an error in the hook_permissions which prevented the permission from showing up. Plus the tests needed to be updated to account for Backdrop.

I figured while I was doing this that it would be better to take advantage of Backdrop storing node type config in separate files and put these variables there. So now on install/uninstall it should add and remove those variables from the right node type. It means we don't have to worry about when a node type is deleted; it'll just remove these variables too.

Let me know what you think. I can update my PR if needed.